### PR TITLE
Collision adjustment

### DIFF
--- a/Scenes/Level1.tscn
+++ b/Scenes/Level1.tscn
@@ -5537,9 +5537,6 @@ separation = Vector2i(1, 1)
 4:1/0 = 0
 5:1/0 = 0
 6:1/0 = 0
-7:1/0 = 0
-8:1/0 = 0
-9:1/0 = 0
 10:1/0 = 0
 12:1/0 = 0
 13:1/0 = 0
@@ -5556,14 +5553,14 @@ separation = Vector2i(1, 1)
 2:2/0 = 0
 3:2/0 = 0
 4:2/0 = 0
+4:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
 5:2/0 = 0
+5:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
 6:2/0 = 0
-7:2/0 = 0
-8:2/0 = 0
-9:2/0 = 0
 10:2/0 = 0
 11:2/0 = 0
 12:2/0 = 0
+12:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
 13:2/0 = 0
 14:2/0 = 0
 15:2/0 = 0
@@ -5574,17 +5571,23 @@ separation = Vector2i(1, 1)
 20:2/0 = 0
 21:2/0 = 0
 0:3/0 = 0
+0:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
 1:3/0 = 0
+1:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
 3:3/0 = 0
 4:3/0 = 0
+4:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
 5:3/0 = 0
+5:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
 6:3/0 = 0
 7:3/0 = 0
 8:3/0 = 0
 9:3/0 = 0
 10:3/0 = 0
 11:3/0 = 0
+11:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
 12:3/0 = 0
+12:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
 14:3/0 = 0
 15:3/0 = 0
 16:3/0 = 0
@@ -5595,6 +5598,7 @@ separation = Vector2i(1, 1)
 21:3/0 = 0
 8:4/0 = 0
 11:4/0 = 0
+11:4/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
 12:4/0 = 0
 13:4/0 = 0
 14:4/0 = 0
@@ -5602,7 +5606,14 @@ separation = Vector2i(1, 1)
 21:4/0 = 0
 13:3/0 = 0
 2:3/0 = 0
+2:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
 11:1/0 = 0
+7:2/0 = 0
+8:2/0 = 0
+9:1/0 = 0
+9:2/0 = 0
+7:1/0 = 0
+8:1/0 = 0
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_ud1sj"]
 texture = ExtResource("9_q1ws5")
@@ -9511,7 +9522,9 @@ texture = ExtResource("10_yji5v")
 27:20/0 = 0
 28:20/0 = 0
 29:20/0 = 0
+29:20/0/physics_layer_0/polygon_0/points = PackedVector2Array(8, -8, 8, 8, -8, 8)
 30:20/0 = 0
+30:20/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, 8, -8, 8)
 31:20/0 = 0
 32:20/0 = 0
 33:20/0 = 0
@@ -9558,6 +9571,7 @@ texture = ExtResource("10_yji5v")
 26:21/0 = 0
 27:21/0 = 0
 28:21/0 = 0
+28:21/0/physics_layer_0/polygon_0/points = PackedVector2Array(8, -8, 8, 8, -8, 8)
 29:21/0 = 0
 30:21/0 = 0
 31:21/0 = 0
@@ -9605,6 +9619,7 @@ texture = ExtResource("10_yji5v")
 25:22/0 = 0
 26:22/0 = 0
 27:22/0 = 0
+27:22/0/physics_layer_0/polygon_0/points = PackedVector2Array(8, -8, 0.629505, -0.899294, 0.809364, 3.0576, 3.50724, 3.0576, 8, 8, 8, 8)
 28:22/0 = 0
 29:22/0 = 0
 30:22/0 = 0
@@ -19711,6 +19726,7 @@ separation = Vector2i(1, 1)
 130:0/0 = 0
 
 [sub_resource type="TileSet" id="TileSet_2llne"]
+physics_layer_0/collision_layer = 1
 sources/4 = SubResource("TileSetAtlasSource_joc8x")
 sources/0 = SubResource("TileSetAtlasSource_384de")
 sources/1 = SubResource("TileSetAtlasSource_bhaf5")
@@ -19727,10 +19743,13 @@ sources/11 = SubResource("TileSetAtlasSource_1nrjw")
 [node name="Main" type="Node2D"]
 
 [node name="Player" parent="." instance=ExtResource("1_2llne")]
-position = Vector2(11, 241)
+position = Vector2(12, 241)
 scale = Vector2(0.016, 0.016)
+
+[node name="Camera2D" type="Camera2D" parent="Player"]
+zoom = Vector2(4, 4)
 
 [node name="Level" type="TileMapLayer" parent="."]
 position = Vector2(411, 89)
-tile_map_data = PackedByteArray("AADm/woABAAAAAMAAADn/woABAABAAMAAADo/woABAABAAMAAADp/woABAABAAMAAADq/woABAABAAMAAADr/woABAABAAMAAADs/woABAABAAMAAADt/woABAABAAMAAADu/woABAABAAMAAADv/woABAABAAMAAADw/woABAABAAMAAADx/woABAABAAMAAADy/woABAABAAMAAADz/woABAABAAMAAAD0/woABAABAAMAAAD1/woABAABAAMAAAD2/woABAABAAMAAAD3/woABAABAAMAAAD4/woABAABAAMAAAD5/woABAABAAMAAAD6/woABAABAAMAAAD7/woABAABAAMAAAD8/woABAABAAMAAAD9/woABAABAAMAAAD+/woABAABAAMAAAD//woABAABAAMAAAAAAAoABAABAAMAAAABAAoABAABAAMAAAACAAoABAABAAMAAAADAAoABAACAAMAAAD8/wkABAAGAAMAAAD8/wgABAAGAAIAAAD//wkABAAKAAMAAAD//wgABAAKAAIAAAD//wcABAAKAAEAAAD//wYABAAKAAAAAAAAAAYABAALAAAAAAABAAYABAAMAAAAAAACAAYABAANAAAAAAACAAcABAANAAEAAAACAAgABAANAAIAAAACAAkABAANAAMAAAAAAAcABAAMAAEAAAABAAcABAAMAAEAAAABAAgABAAMAAEAAAABAAkABAAMAAEAAAAAAAkABAAMAAEAAAAAAAgABAAMAAEAAAD5/wkABAALAAEAAADo/wkABAALAAEAAADr/wkABAAEAAMAAADs/wkABAAFAAMAAADs/wgABAAFAAIAAADr/wgABAAFAAIAAADs/wcABAAEAAIAAAA=")
+tile_map_data = PackedByteArray("AADm/woABAABAAMAAADn/woABAABAAMAAADo/woABAABAAMAAADp/woABAABAAMAAADq/woABAABAAMAAADr/woABAABAAMAAADs/woABAABAAMAAADt/woABAABAAMAAADu/woABAABAAMAAADv/woABAABAAMAAADw/woABAABAAMAAADx/woABAABAAMAAADy/woABAABAAMAAADz/woABAABAAMAAAD0/woABAABAAMAAAD1/woABAABAAMAAAD2/woABAABAAMAAAD3/woABAABAAMAAAD4/woABAABAAMAAAD5/woABAABAAMAAAD6/woABAABAAMAAAD7/woABAABAAMAAAD8/woABAABAAMAAAD9/woABAABAAMAAAD+/woABAABAAMAAAD//woABAABAAMAAAAAAAoABAABAAMAAAABAAoABAABAAMAAAACAAoABAABAAMAAAADAAoABAACAAMAAAD8/wkABAAGAAMAAAD8/wgABAAGAAIAAAD//wkABAAKAAMAAAD//wgABAAKAAIAAAD//wcABAAKAAEAAAD//wYABAAKAAAAAAAAAAYABAALAAAAAAABAAYABAAMAAAAAAACAAYABAANAAAAAAACAAcABAANAAEAAAACAAgABAANAAIAAAACAAkABAANAAMAAAAAAAcABAAMAAEAAAABAAcABAAMAAEAAAABAAgABAAMAAEAAAABAAkABAAMAAEAAAAAAAkABAAMAAEAAAAAAAgABAAMAAEAAAD5/wkABAALAAEAAADo/wkABAALAAEAAADr/wkABAAEAAMAAADs/wkABAAFAAMAAADs/wgABAAFAAIAAADr/wgABAAFAAIAAADs/wcABAAEAAIAAADk/wgABgAbABYAAADl/wcABgAcABUAAADm/wcABgAdABUAAADm/wYABgAdABQAAADn/wYABgAeABQAAADl/woABAABAAMAAADk/woABAABAAMAAADj/woABAABAAMAAADi/woABAABAAMAAADh/woABAABAAMAAADg/woABAABAAMAAADf/woABAAAAAMAAAA=")
 tile_set = SubResource("TileSet_2llne")

--- a/Scenes/player.tscn
+++ b/Scenes/player.tscn
@@ -4,8 +4,6 @@
 [ext_resource type="Texture2D" uid="uid://bskvqfw7odidf" path="res://Assets/Sprites/morganWalk1.png" id="2_vgqql"]
 [ext_resource type="Texture2D" uid="uid://21psrnlam460" path="res://Assets/Sprites/morganWalk2.png" id="3_fkybt"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_f60y1"]
-
 [sub_resource type="SpriteFrames" id="SpriteFrames_x3wgy"]
 animations = [{
 "frames": [{
@@ -28,12 +26,18 @@ animations = [{
 "speed": 3.0
 }]
 
+[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_6t5aa"]
+radius = 156.0
+height = 734.0
+
 [node name="Player" type="CharacterBody2D"]
 script = ExtResource("1_6t5aa")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-shape = SubResource("RectangleShape2D_f60y1")
-
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+z_index = 5
 sprite_frames = SubResource("SpriteFrames_x3wgy")
 animation = &"Move"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(77, 80)
+shape = SubResource("CapsuleShape2D_6t5aa")


### PR DESCRIPTION
-extended player hitbox; to stand on the ground instead of inside the ground further adjustmnet needed
-added collision to some tiles so you do not instantly just fall through the floor
-added camera to follow player
-put the layer of the player model on 5 so it renders in front of other level elements